### PR TITLE
fix broken tests

### DIFF
--- a/src/Domain/Domain.Tests/DomainObjectTests/Visiting/WhenVisiting.cs
+++ b/src/Domain/Domain.Tests/DomainObjectTests/Visiting/WhenVisiting.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using BE.CQRS.Domain.Configuration;
+using BE.CQRS.Domain.DomainObjects;
 using BE.CQRS.Domain.Events;
 using Xunit;
 
@@ -21,6 +23,10 @@ namespace BE.CQRS.Domain.Tests.DomainObjectTests.Visiting
             };
 
             sut.ApplyEvents(events);
+            sut.ApplyConfig(new EventSourceConfiguration
+            {
+                StateActivator = new ActivatorDomainObjectActivator()
+            });
 
             sut.RaiseEvent();
             VisitorState = sut.State<SampleVisitor>();

--- a/src/Domain/Domain/Events/Handlers/ConventionEventHandler.cs
+++ b/src/Domain/Domain/Events/Handlers/ConventionEventHandler.cs
@@ -89,7 +89,7 @@ namespace BE.CQRS.Domain.Events.Handlers
                 }
             }
             watch.Stop();
-            logger.LogTrace("\"{type.FullName}\" handled in {watch.ElapsedMilliseconds}ms",type.FullName,watch.ElapsedMilliseconds);
+            logger?.LogTrace("\"{type.FullName}\" handled in {watch.ElapsedMilliseconds}ms",type.FullName,watch.ElapsedMilliseconds);
         }
 
         private async Task SafeInvoke(IEvent @event, EventHandlerMethod method,


### PR DESCRIPTION
resolve #31 

Broken tests are caused by lack of Guard for `StateActivator`, see #32 